### PR TITLE
add disableRemotePlayback to spinning logo videos

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -22,7 +22,7 @@
   <body>
     <div id="faq">
       <header>
-        <video autoplay playsinline loop muted title="Radicle Token logo spining in 3D along a vertical axis.">
+        <video disableRemotePlayback autoplay playsinline loop muted title="Radicle Token logo spining in 3D along a vertical axis.">
           <source type="video/mp4" src="img/spinning-logo.mp4">
         </video>
         <h1>Questions</h1>

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,7 +65,7 @@
       <hr>
 
       <div class="spinner">
-        <video autoplay playsinline loop muted title="Radicle Token logo spining in 3D along a vertical axis.">
+        <video disableRemotePlayback autoplay playsinline loop muted title="Radicle Token logo spining in 3D along a vertical axis.">
           <source type="video/mp4" src="img/spinning-token.mp4">
         </video>
       </div>


### PR DESCRIPTION
On Android, there's some ugly Chromecast buttons showing up on the videos. Just removes them from the tag.

![image](https://user-images.githubusercontent.com/4406983/109223833-6d396600-77bb-11eb-9743-39a3c5d0a68c.png)
![image](https://user-images.githubusercontent.com/4406983/109223848-70cced00-77bb-11eb-881f-ca05ebddc921.png)
