### PR TITLE
Fix the link of official website in about section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -72,7 +72,7 @@
 
       <div class="meta">
         <h3>About Radicle</h3>
-        <p><a href="radicle.xyz">Radicle</a> is the first open-source, community-led, and self-sustaining network for software collaboration. With Ethereum, Radicle is harnessing the power of Ethereum and DeFi in order to enable developers to truly own their collaboration infrastructure. The network’s code and treasury of assets are publicly managed fully in the open allowing any developer to contribute and influence the direction of the project.</p>
+        <p><a href="https://radicle.xyz">Radicle</a> is the first open-source, community-led, and self-sustaining network for software collaboration. With Ethereum, Radicle is harnessing the power of Ethereum and DeFi in order to enable developers to truly own their collaboration infrastructure. The network’s code and treasury of assets are publicly managed fully in the open allowing any developer to contribute and influence the direction of the project.</p>
       </div>
 
       <div class="meta">


### PR DESCRIPTION
It redirects to https://lbp.radicle.network/radicle.xyz currently now.